### PR TITLE
StatementCache fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # fauxjo
 A database persistence layer for the real world.
-- 11.3.0-7 Allow Home and Table to disable StatementCache, fixed its
-memory leaks and added LRU guard for every-changing sql. Added comments 
-that are needed to ensure safe use in production.
+- 11.3.0-7 Added a listener for and updated StatementCache to work with HikariCP including rapid recovery support and configuration comments. Added ability to disable it via its Home and related comments. Also added a configurable LRU to it to avoid memory leaks from PreparedStatement/CallableStatement sql that incorrectly concatenates criteria instead of uses parameters.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # fauxjo
 A database persistence layer for the real world.
+11.3.0-7 Allow Home and Table to disable StatementCache, fixed its 
+memory leaks and added LRU guard for every-changing sql. Added comments 
+that are needed to ensure safe use in production.
+

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>fauxjo</artifactId>
     <name>fauxjo</name>
     <packaging>jar</packaging>
-    <version>11.3.0-5</version>
+    <version>11.3.0-7</version>
     <url>https://github.com/jextranet/fauxjo</url>
     <description>A database persistence layer for the real world.</description>
 

--- a/src/main/java/net/jextra/fauxjo/StatementCacheListener.java
+++ b/src/main/java/net/jextra/fauxjo/StatementCacheListener.java
@@ -1,0 +1,52 @@
+package net.jextra.fauxjo;
+
+import java.sql.*;
+
+/**
+ * Receive events related to caching PreparedStatements or CallableStatements.
+ * Used to log and diagnose affinity of the caches to its threads, connections and statements.
+ * <ul>
+ * <li>A new ThreadLocal StmtCacheMap is created when a prepare/callStatement request is from a new Thread.</li>
+ * <li>A new StmtCache (StatementCache.PerConnectionCache) is created and cached in the StmtCacheMap
+ *     by its Connection when the prepare/callStatement request encounters a new Connection.</li>
+ * <li>The least recently used Prepared/CallableStatement will be evicted from the StmtCache if expired or StmtCache
+ *     fills up to guard against Prepared/CallableStatements with concatenated criteria instead of using parameters.</li>
+ * </ul>
+ */
+public interface StatementCacheListener {
+
+    public enum StmtType {
+        Prepared, Callable
+    }
+    public enum EvictType {
+        MaxTtl, MaxEntries
+    }
+
+    /** Per prepare/callStatement, the eldest Statement is evicted if cache has this many entries. */
+    public void setStmtCacheMaxEntries(StatementCache.CacheType ctype, Thread t, Integer maxStmts);
+    /** Per prepare/callStatement call, the eldest Statement is evicted if older than this value. */
+    public void setStmtCacheMaxTtl(StatementCache.CacheType ctype, Thread t, Long maxTTL);
+
+    /** * The least recently used statement was evicted, StmtCache would have exceeded maxEntries. */
+    public void evictedLruStmt_MaxEntries(StatementCache.CacheType ctype, StmtType type, String sql, long createdOnTs, long accessedCn, long maxCacheEntries);
+    /** * The least recently used statement was evicted, it exceeded its maxTtl. */
+    public void evictedLruStmt_MaxTtl(StatementCache.CacheType ctype, StmtType type, String sql, long createdOnTs, long ageMillisMax, long accessedCn);
+    /** * An exception was thrown while trying to close an evicted Statement. */
+    public void evictLruStmtException(StatementCache.CacheType ctype, StmtType type, Throwable throwable);
+
+    /** * A new Thread was encountered resulting in a new ThreadLocal StmtCacheMap. */
+    public void newStmtCacheMapForNewThread(StatementCache.CacheType ctype, Thread t);
+    /** * An uncached Connection from prepare/callStatement request created a new StmtCache in StmtCacheMap. */
+    public void newStmtCacheForNewConn(StatementCache.CacheType ctype,  Thread t, Long dbConKey, String stmtSql);
+
+    /** * StatementCache.clear was called so its listeners, StmtCacheMap and StmtCaches have been released. */
+    public void clearedStmtCacheMapForThread(StatementCache.CacheType ctype, Thread t);
+    /** * StatementCache.clear(Connection) was called so its StmtCache was released. */
+    public void clearedStmtCacheForConn(StatementCache.CacheType ctype,  Thread t, Long dbConKey);
+
+    public void preparedStmt(StatementCache.CacheType ctype, Thread t, Long dbConKey);
+    public void preparedCall(StatementCache.CacheType ctype, Thread t, Long dbConKey);
+    public void reusedStmt(StatementCache.CacheType ctype, Thread t, Long dbConKey);
+
+
+}

--- a/src/main/java/net/jextra/fauxjo/Table.java
+++ b/src/main/java/net/jextra/fauxjo/Table.java
@@ -43,7 +43,9 @@ public class Table<T>
 
     private boolean supportsGeneratedKeys;
     private Connection conn;
+    private Long connKey;
     private StatementCache statementCache;
+    private boolean stmtCacheEnabled;
     private String fullTableName;
     private String schemaName;
     private String tableName;
@@ -56,6 +58,10 @@ public class Table<T>
 
     private String updateSql;
     private String deleteSql;
+
+    private List<StatementCacheListener> listeners;
+    private Integer perConCache_MaxEntries;
+    private Long perConCache_MaxTtl;
 
     // ============================================================
     // Constructors
@@ -99,20 +105,84 @@ public class Table<T>
         this.supportsGeneratedKeys = value;
     }
 
-    public void setConnection( Connection conn )
+    /**
+     * Sets the StatementCache enabled (default) if true.<p>
+     *
+     * StatementCaching is enabled by default to avoid breaking changes but should
+     * be disabled when using a modern jdbc driver. Per the Hikari author who has
+     * deep domain expertise in statement caching, nobody can cache statements better
+     * than the jdbc driver. Of the 5 most popular rdbms, only Microsoft SQLServer
+     * jdbc driver does not fully support transparent, driver-side statement caching.
+     * @param enabled should be set prior to setConnection
+     * @see <a href="https://github.com/brettwooldridge/HikariCP/issues/488">https://github.com/brettwooldridge/HikariCP/issues/488</a>
+     */
+    public Table setStatementCacheEnabled(boolean enabled) {
+        this.stmtCacheEnabled = enabled;
+        return this;
+    }
+
+    /**
+     * Sets configuration passed to StatementCache if it is or becomes enabled.<p>
+     *
+     * Enables logging and aids diagnosing affinity of cache, thread, connection and its sql statements.
+     * @param listeners to receive key StatementCache events
+     * @param perConCache_MaxEntries max Statements cached per Connection prevents sql concatenation leaks (default is 1000 entries)
+     * @param perConCache_MaxTtl max time millis a Statement is cached per Connection prevents sql concatenation (default is 30 minutes)
+     * @see #setConnection(Connection)
+     */
+    public Table setStatementCacheConfig(List<StatementCacheListener> listeners, Integer perConCache_MaxEntries, Long perConCache_MaxTtl)
+    {
+        this.listeners = listeners;
+        this.perConCache_MaxEntries = perConCache_MaxEntries;
+        this.perConCache_MaxTtl = perConCache_MaxTtl;
+        if(statementCache != null)
+        {
+            if(listeners != null) for(StatementCacheListener l : listeners) statementCache.addListener( l );
+            statementCache.setPerConCache_Maximums( perConCache_MaxEntries, perConCache_MaxTtl );
+        }
+        return this;
+    }
+
+    /**
+     * Return true if stmtCache is enabled and the Connection is the same as last.<p>
+     *
+     * Otherwise, clears the StatementCache and creates a new StatementCache.
+     * The internal connection reference is set for both cases because conn may be a
+     * Connection facade such as if from HikariCP.getConnection.
+     * net.jextra.fauxjo.StatementCache#getConnKey(Connection) is used to determine
+     * if conn is the same as the last one set.
+     * @param conn may be a real db Connection or one wrapped in a Connection facade
+     * @see net.jextra.fauxjo.StatementCache#getConnKey(Connection)
+     */
+    public boolean setConnection( Connection conn )
         throws SQLException
     {
-        if ( statementCache != null )
+        if(!stmtCacheEnabled) {
+            this.conn = conn; //Update conn in case it is a new connection wrapper.
+            return false; //do not clear the statementCache.
+        }
+        Long connkey = StatementCache.getConnKey( conn );
+        if(this.connKey != null && connkey.longValue() == this.connKey.longValue())
+        {
+            this.conn = conn; //Update conn in case it is a new connection wrapper.
+            return true; //If same Connection reuse it. Do not clear the statementCache.
+        }
+
+        //Is a new unique Connection so release all resources
+        if (statementCache != null )
         {
             statementCache.clear();
-            statementCache = null;
         }
 
         this.conn = conn;
-        if ( conn != null )
+        this.connKey = connkey;
+        if (conn != null )
         {
-            statementCache = new StatementCache();
+            statementCache = new StatementCache().setCacheType(StatementCache.CacheType.Home);
+            if(listeners != null) for(StatementCacheListener l : listeners) statementCache.addListener( l );
+            statementCache.setPerConCache_Maximums( perConCache_MaxEntries, perConCache_MaxTtl );
         }
+        return false;
     }
 
     public String getSchemaName()
@@ -153,8 +223,19 @@ public class Table<T>
         throws SQLException
     {
         InsertDef insertDef = getInsertDef( bean );
-        PreparedStatement insStatement = statementCache.prepareStatement( conn, insertDef.getInsertSql(), supportsGeneratedKeys );
-
+        PreparedStatement insStatement = null;
+        if( stmtCacheEnabled && statementCache != null)
+        {
+            insStatement = statementCache.prepareStatement( conn, insertDef.getInsertSql(), supportsGeneratedKeys );
+        }
+        else if ( supportsGeneratedKeys && SqlInspector.isInsertStatement( insertDef.getInsertSql() ) )
+        {
+            insStatement = conn.prepareStatement( insertDef.getInsertSql(), Statement.RETURN_GENERATED_KEYS );
+        }
+        else
+        {
+            insStatement = conn.prepareStatement( insertDef.getInsertSql() );
+        }
         setInsertValues( insStatement, insertDef, 1, bean );
         int rows = insStatement.executeUpdate();
         retrieveGeneratedKeys( insStatement, insertDef, bean );
@@ -175,7 +256,19 @@ public class Table<T>
 
         InsertDef insertDef = getInsertDef( null );
         insertDef.setRowCount( beans.size() );
-        PreparedStatement insStatement = statementCache.prepareStatement( conn, insertDef.getInsertSql(), supportsGeneratedKeys );
+        PreparedStatement insStatement = null;
+        if( stmtCacheEnabled && statementCache != null)
+        {
+            insStatement = statementCache.prepareStatement( conn, insertDef.getInsertSql(), supportsGeneratedKeys );
+        }
+        else if ( supportsGeneratedKeys && SqlInspector.isInsertStatement( insertDef.getInsertSql() ) )
+        {
+            insStatement = conn.prepareStatement( insertDef.getInsertSql(), Statement.RETURN_GENERATED_KEYS );
+        }
+        else
+        {
+            insStatement = conn.prepareStatement( insertDef.getInsertSql() );
+        }
 
         int paramIndex = 1;
         for ( T bean : beans )
@@ -199,7 +292,19 @@ public class Table<T>
         }
 
         InsertDef insertDef = getInsertDef( null );
-        PreparedStatement insStatement = statementCache.prepareStatement( conn, insertDef.getInsertSql(), supportsGeneratedKeys );
+        PreparedStatement insStatement = null;
+        if( stmtCacheEnabled && statementCache != null)
+        {
+            insStatement = statementCache.prepareStatement( conn, insertDef.getInsertSql(), supportsGeneratedKeys );
+        }
+        else if ( supportsGeneratedKeys && SqlInspector.isInsertStatement( insertDef.getInsertSql() ) )
+        {
+            insStatement = conn.prepareStatement( insertDef.getInsertSql(), Statement.RETURN_GENERATED_KEYS );
+        }
+        else
+        {
+            insStatement = conn.prepareStatement( insertDef.getInsertSql() );
+        }
 
         for ( T bean : beans )
         {
@@ -218,7 +323,18 @@ public class Table<T>
     public int update( T bean )
         throws SQLException
     {
-        PreparedStatement statement = statementCache.prepareStatement( conn, getUpdateSql(), supportsGeneratedKeys );
+        PreparedStatement statement = null;
+        if( stmtCacheEnabled && statementCache != null) {
+            statement = statementCache.prepareStatement( conn, getUpdateSql(), supportsGeneratedKeys );
+        }
+        else if ( supportsGeneratedKeys && SqlInspector.isInsertStatement( getUpdateSql() ) )
+        {
+            statement = conn.prepareStatement( getUpdateSql(), Statement.RETURN_GENERATED_KEYS );
+        }
+        else
+        {
+            statement = conn.prepareStatement( getUpdateSql() );
+        }
         setUpdateValues( statement, bean );
 
         return statement.executeUpdate();
@@ -230,7 +346,18 @@ public class Table<T>
     public boolean delete( T bean )
         throws SQLException
     {
-        PreparedStatement statement = statementCache.prepareStatement( conn, getDeleteSql(), supportsGeneratedKeys );
+        PreparedStatement statement = null;
+        if( stmtCacheEnabled && statementCache != null) {
+            statement = statementCache.prepareStatement( conn, getDeleteSql(), supportsGeneratedKeys );
+        }
+        else if ( supportsGeneratedKeys && SqlInspector.isInsertStatement( getDeleteSql() ) )
+        {
+            statement = conn.prepareStatement( getDeleteSql(), Statement.RETURN_GENERATED_KEYS );
+        }
+        else
+        {
+            statement = conn.prepareStatement( getDeleteSql() );
+        }
         setDeleteValues( statement, bean );
 
         return statement.executeUpdate() > 0;
@@ -399,6 +526,20 @@ public class Table<T>
             statement.setObject( paramIndex, coercedValue, value.getSqlType() );
             paramIndex++;
         }
+    }
+
+    /**
+     * Append the contents of the StatementCache for the current Connection.
+     * @param sb will have cache entries appended
+     */
+    public void getStatementCacheCsvForPrepStmts(StringBuilder sb)
+        throws Exception
+    {
+        if( stmtCacheEnabled && statementCache != null)
+        {
+            statementCache.getDiagnosticCsv( conn, sb );
+        }
+        throw new SQLException("stmtCacheEnabled is false");
     }
 
     // ----------


### PR DESCRIPTION
Added a listener for and updated StatementCache to work with HikariCP including rapid recovery support and configuration comments. Added ability to disable it via its Home and related comments. Also added a configurable LRU to it to avoid  memory leaks from PreparedStatement/CallableStatement sql that incorrectly concatenates criteria instead of uses parameters. 