### PR TITLE
ResultSetIterator AutoCloseable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # fauxjo
 A database persistence layer for the real world.
 
+11.3.0-12   Made ResultSetIterator AutoCloseable so that it could be used in the new-style 
+            an auto-closable try block.
+
 11.3.0-11   Made HomeGroup AutoCloseable so that it could be used in the new-style an
             auto-closable try block.
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>fauxjo</artifactId>
     <name>fauxjo</name>
     <packaging>jar</packaging>
-    <version>11.3.0-11</version>
+    <version>11.3.0-12</version>
     <url>https://github.com/jextranet/fauxjo</url>
     <description>A database persistence layer for the real world.</description>
 

--- a/src/main/java/net/jextra/fauxjo/ResultSetIterator.java
+++ b/src/main/java/net/jextra/fauxjo/ResultSetIterator.java
@@ -29,7 +29,7 @@ import java.util.*;
  * Fauxjo bean. This is used primarily to iterate over a large number records without having to
  * load them all into memory.
  */
-public class ResultSetIterator<T> implements Iterator<T>, Iterable<T>
+public class ResultSetIterator<T> implements Iterator<T>, Iterable<T>, AutoCloseable
 {
     // ============================================================
     // Fields
@@ -104,6 +104,7 @@ public class ResultSetIterator<T> implements Iterator<T>, Iterable<T>
         throw new UnsupportedOperationException( "Remove is not supported for " + "ResultSetIterators." );
     }
 
+    @Override
     public void close()
         throws SQLException
     {


### PR DESCRIPTION
Made ResultSetIterator AutoCloseable so that it could be used in the new-style an auto-closable try block.