### PR TITLE
Added Batched Update Statements

### DIFF
--- a/src/main/java/net/jextra/fauxjo/Home.java
+++ b/src/main/java/net/jextra/fauxjo/Home.java
@@ -220,6 +220,12 @@ public class Home<T> implements AutoCloseable
         return table.insert( beans );
     }
 
+    public int[] update( Collection<T> beans )
+        throws SQLException
+    {
+        return table.updateBatch( beans );
+    }
+
     public int update( T bean )
         throws SQLException
     {

--- a/src/main/java/net/jextra/fauxjo/Table.java
+++ b/src/main/java/net/jextra/fauxjo/Table.java
@@ -457,9 +457,9 @@ public class Table<T> implements AutoCloseable
      * Update multiple beans in the database in one batched statement using a batched PreparedStatement.
      * If StatementCache is enabled, the PreparedStatement will be closed upon
      * the next new Connection else is closed here in a finally block.
-     * @param beans Collection of beans to be updated
-     * @throws SQLException For errors generating SQL, executing the statement, or closing the connection
-     * @return int[] Where each int is the number of rows updated for a given update statement in the batch
+     * @param beans Collection of beans to be updated.
+     * @throws SQLException For errors generating SQL, executing the statement, or closing the connection.
+     * @return int[] Where each int is the number of rows updated for a given update statement in the batch.
      */
     public int[] updateBatch( Collection<T> beans )
         throws SQLException


### PR DESCRIPTION
Added ability to use PreparedStatement batching to update a collection of beans.

This allows users to avoid sending single bean updates and instead batch them together which should improve performance for scenarios where bulk updates are appropriate.

For reference - this method is very similar to the already existing insertBatch method.